### PR TITLE
change the way to perform in database deliver

### DIFF
--- a/lib/noticed/base.rb
+++ b/lib/noticed/base.rb
@@ -106,14 +106,7 @@ module Noticed
         # If the queue is `nil`, ActiveJob will use a default queue name.
         queue = delivery_method.dig(:options, :queue)
 
-        # Always perfrom later if a delay is present
-        if (delay = delivery_method.dig(:options, :delay))
-          method.set(wait: delay, queue: queue).perform_later(args)
-        elsif enqueue
-          method.set(queue: queue).perform_later(args)
-        else
-          method.perform_now(args)
-        end
+        method.perform_now(args)
       end
     end
 

--- a/lib/noticed/delivery_methods/base.rb
+++ b/lib/noticed/delivery_methods/base.rb
@@ -33,12 +33,12 @@ module Noticed
         @notification = args[:notification_class].constantize.new(args[:params])
         @options = args[:options]
         @params = args[:params]
-        @recipient = args[:recipient]
         @record = args[:record]
+        @recipient = args[:recipient]
 
         # Make notification aware of database record and recipient during delivery
-        @notification.record = args[:record]
-        @notification.recipient = args[:recipient]
+        @notification.record = record
+        @notification.recipient = recipient
 
         return if (condition = @options[:if]) && !@notification.send(condition)
         return if (condition = @options[:unless]) && @notification.send(condition)

--- a/lib/noticed/delivery_methods/database.rb
+++ b/lib/noticed/delivery_methods/database.rb
@@ -55,8 +55,21 @@ module Noticed
       end
 
       def save_notifications(notifications)
-        ids = klass.insert_all!(notifications).rows
-        klass.find(ids)
+        if Rails::VERSION::MAJOR > 6 && ["postgresql", "postgis"].include?(current_adapter)
+          ids = klass.insert_all!(notifications).rows
+          records = klass.find(ids)
+        else
+          records = klass.create!(notifications)
+        end
+        records
+      end
+
+      def current_adapter
+        if ActiveRecord::Base.respond_to?(:connection_db_config)
+          ActiveRecord::Base.connection_db_config.adapter
+        else
+          ActiveRecord::Base.connection_config[:adapter]
+        end
       end
     end
   end

--- a/test/delivery_methods/database_test.rb
+++ b/test/delivery_methods/database_test.rb
@@ -50,10 +50,10 @@ class DatabaseTest < ActiveSupport::TestCase
   test "deliver returns the created record" do
     args = {
       notification_class: "Noticed::Base",
-      recipient: user,
+      recipients: user,
       options: {}
     }
-    record = Noticed::DeliveryMethods::Database.new.perform(args)
+    record = Noticed::DeliveryMethods::Database.new.perform(args).first
 
     assert_kind_of ActiveRecord::Base, record
   end


### PR DESCRIPTION
In [briq.mx](https://www.briq.mx), we have this problem excid3#137.

Here we have tried to solve it using `insert_all` to create all the notifications at once.

We have changed `Noticed::Base#deliver` to pass all `recipients` to `run_delivery`.

```ruby
def run_delivery(recipients, enqueue: true)
  delivery_methods = self.class.delivery_methods.dup
  # Run database delivery inline first if it exists so other methods have access to the record
  if (index = delivery_methods.find_index { |m| m[:name] == :database })
      delivery_method = delivery_methods.delete_at(index)
      records = run_database_delivery_method(delivery_method, recipients: recipients, enqueue: false)
    end

    recipients.each do |recipient|
        record = Array.wrap(records).detect{|record| record.recipient == recipient}
        delivery_methods.each do |delivery_method|
        run_delivery_method(delivery_method, recipient: recipient, enqueue: enqueue, record: record)
    end
  end
end
```